### PR TITLE
Fixup to work with set -u

### DIFF
--- a/ghettopt.bash
+++ b/ghettopt.bash
@@ -31,7 +31,7 @@ ghettopt() {
 
     # Extract long options from variable declarations.
     for o in $(compgen -A variable opt_); do
-      v=${!o}; o=${o#opt_}; o=${o//_/-}
+      v=${!o:-}; o=${o#opt_}; o=${o//_/-}
       if [[ $v == false || $v == true ]]; then
         longs=( "${longs[@]}" "${o//_/-}" "no-${o//_/-}" )
       else


### PR DESCRIPTION
Following on from https://github.com/agriffis/pure-getopt/pull/8, this change seems to be all that is required for `ghettopts.bash` to function (pun intended) under `set -u`.